### PR TITLE
fix: Add missing admin.audit-logs route

### DIFF
--- a/routes/web.php
+++ b/routes/web.php
@@ -404,6 +404,9 @@ Route::middleware(['auth'])->group(function () {
         Route::get('/settings', [UserController::class, 'settings'])->name('settings');
         Route::post('/settings', [UserController::class, 'updateSettings'])->name('settings.update');
 
+        // Audit Logs (from UserController)
+        Route::get('/audit-logs', [UserController::class, 'auditLogs'])->name('audit-logs');
+
         // Activity Logs
         Route::get('/activity-logs', [ActivityLogController::class, 'index'])->name('activity-logs');
         Route::get('/activity-logs/statistics', [ActivityLogController::class, 'statistics'])->name('activity-logs.statistics');


### PR DESCRIPTION
Fixed RouteNotFoundException error on dashboard by adding the missing admin.audit-logs route that was referenced in dashboard/index.blade.php but not defined in web.php.

Changes:
- Added admin.audit-logs route pointing to UserController@auditLogs
- Route is protected by auth and role:admin middleware
- Resolves "Route [admin.audit-logs] not defined" error

This route was already implemented in UserController but was missing from the routes file, causing the dashboard to crash when trying to render the "View All" link for recent activities.