### PR TITLE
fix: Correct settings route to include admin prefix

### DIFF
--- a/resources/views/admin/settings.blade.php
+++ b/resources/views/admin/settings.blade.php
@@ -22,7 +22,7 @@
         <div class="col-md-9">
             <div class="card">
                 <div class="card-body">
-                    <form method="POST" action="{{ route('settings.update') }}">
+                    <form method="POST" action="{{ route('admin.settings.update') }}">
                         @csrf
 
                         <div id="general" class="settings-section">


### PR DESCRIPTION
- Changed route('settings.update') to route('admin.settings.update')
- Route is defined in admin namespace so needs admin. prefix
- Fixes 'Route [settings.update] not defined' error