### PR TITLE
fix: Comprehensive seeder schema alignment

### DIFF
--- a/check-all-tables.php
+++ b/check-all-tables.php
@@ -1,0 +1,53 @@
+<?php
+
+require __DIR__.'/vendor/autoload.php';
+$app = require_once __DIR__.'/bootstrap/app.php';
+$app->make('Illuminate\Contracts\Console\Kernel')->bootstrap();
+
+use Illuminate\Support\Facades\DB;
+
+$tables = [
+    'campuses',
+    'oeps',
+    'trades',
+    'users',
+    'batches',
+    'candidates',
+    'candidate_trainings',
+    'candidate_screenings',
+    'registration_documents',
+    'next_of_kins',
+    'undertakings',
+    'visa_processes',
+    'departures',
+    'complaints',
+    'correspondence',
+    'remittances',
+    'document_archives',
+];
+
+foreach ($tables as $table) {
+    echo "\n═══════════════════════════════════════════════════════════\n";
+    echo strtoupper($table) . " TABLE\n";
+    echo "═══════════════════════════════════════════════════════════\n";
+
+    try {
+        $columns = DB::select("SHOW COLUMNS FROM {$table}");
+
+        foreach ($columns as $column) {
+            $null = $column->Null === 'YES' ? 'nullable' : 'required';
+            $default = $column->Default ? " (default: {$column->Default})" : '';
+            echo sprintf("  %-30s %-20s %s%s\n",
+                $column->Field,
+                $column->Type,
+                $null,
+                $default
+            );
+        }
+    } catch (\Exception $e) {
+        echo "  ❌ Table not found or error: " . $e->getMessage() . "\n";
+    }
+}
+
+echo "\n═══════════════════════════════════════════════════════════\n";
+echo "Done!\n";


### PR DESCRIPTION
Model and import fixes:
- Remove CandidateTraining (model doesn't exist)
- Change VisaProcessing to VisaProcess (correct model name)
- Skip training seeding (no CandidateTraining model)

Batches table fixes:
- instructor_name → trainer_name (correct field name)
- Add description and oep_id fields

VisaProcess table fixes:
- Complete schema rewrite to match actual visa_processes table
- Use interview_date, trade_test_date, medical_date, biometric_date, visa_date
- Add overall_status, ticket_uploaded fields

Departures table fixes:
- Remove non-existent fields: iqama_expiry_date, wps_registration_date, compliance_stage, is_90_day_compliant, compliance_date
- Add correct fields: pre_departure_briefing, post_arrival_medical_path, qiwa_id, qiwa_activated, ninety_day_report_submitted

Add check-all-tables.php diagnostic script