### PR TITLE
fix: Update Candidate model for seeder compatibility

### DIFF
--- a/app/Models/Candidate.php
+++ b/app/Models/Candidate.php
@@ -20,6 +20,7 @@ class Candidate extends Model
      * The attributes that are mass assignable.
      */
     protected $fillable = [
+        'btevta_id',
         'name',
         'cnic',
         'phone',
@@ -28,7 +29,9 @@ class Candidate extends Model
         'batch_id',
         'campus_id',
         'trade_id',
+        'oep_id',
         'district',
+        'tehsil',
         'province',
         'date_of_birth',
         'gender',
@@ -47,6 +50,7 @@ class Candidate extends Model
         'training_end_date',
         'training_status',
         'status',
+        'photo_path',
         'remarks',
         'created_by',
         'updated_by'
@@ -83,7 +87,7 @@ class Candidate extends Model
      */
     protected $attributes = [
         'status' => 'new',
-        'training_status' => 'not_started',
+        'training_status' => 'pending',
     ];
 
     /**


### PR DESCRIPTION
- Change default training_status from 'not_started' to 'pending' (matches enum values: pending, ongoing, completed, failed)
- Add btevta_id to fillable fields (required by seeder)
- Add oep_id to fillable fields (required by seeder)
- Add tehsil to fillable fields (exists in schema)
- Add photo_path to fillable fields (exists in schema)