### PR TITLE
fix: Generate 13-digit CNICs without dashes

### DIFF
--- a/database/seeders/TestDataSeeder.php
+++ b/database/seeders/TestDataSeeder.php
@@ -673,7 +673,8 @@ class TestDataSeeder extends Seeder
 
     private function generateCNIC()
     {
-        return rand(10000, 99999) . '-' . rand(1000000, 9999999) . '-' . rand(1, 9);
+        // Generate 13-digit CNIC without dashes (database stores as varchar(13))
+        return rand(10000, 99999) . str_pad(rand(0, 9999999), 7, '0', STR_PAD_LEFT) . rand(1, 9);
     }
 
     private function generateAddress()


### PR DESCRIPTION
- Database cnic column is varchar(13) - no room for dashes
- Changed CNIC format from 'XXXXX-XXXXXXX-X' (17 chars) to 'XXXXXXXXXXXXX' (13 chars)
- Ensures proper padding of middle 7 digits with leading zeros