### PR TITLE
fix: Handle null dates in complaints dashboard

### DIFF
--- a/app/Models/Complaint.php
+++ b/app/Models/Complaint.php
@@ -176,6 +176,7 @@ class Complaint extends Model
     public function scopeOverdue($query)
     {
         return $query->whereNotIn('status', [self::STATUS_RESOLVED, self::STATUS_CLOSED])
+                     ->whereNotNull('sla_due_date')
                      ->where('sla_due_date', '<', now());
     }
 

--- a/resources/views/dashboard/tabs/complaints.blade.php
+++ b/resources/views/dashboard/tabs/complaints.blade.php
@@ -48,7 +48,11 @@
                     <tbody>
                         @foreach($complaintsList as $complaint)
                             @php
-                                $daysRemaining = $complaint->registered_at->addDays($complaint->sla_days)->diffInDays(now());
+                                // Calculate SLA deadline and days remaining
+                                $slaDueDate = $complaint->sla_due_date ??
+                                              ($complaint->registered_at ? $complaint->registered_at->addDays($complaint->sla_days ?? 7) :
+                                              ($complaint->created_at ? $complaint->created_at->addDays($complaint->sla_days ?? 7) : now()->addDays(7)));
+                                $daysRemaining = now()->diffInDays($slaDueDate, false);
                                 $isOverdue = $daysRemaining < 0;
                             @endphp
                             <tr class="border-b hover:bg-gray-50 {{ $isOverdue ? 'bg-red-50' : '' }}">


### PR DESCRIPTION
Fixed "Call to a member function addDays() on null" error in complaints dashboard.

Changes:
1. Updated complaints view to safely handle null registered_at and created_at dates
   - Now uses sla_due_date if available
   - Falls back to registered_at or created_at with null checks
   - File: resources/views/dashboard/tabs/complaints.blade.php

2. Updated overdue scope to exclude complaints with null sla_due_date
   - Added whereNotNull check before date comparison
   - File: app/Models/Complaint.php

These changes ensure the complaints dashboard works correctly even when date fields are null in the database.