### PR TITLE
fix: Fix candidate entry and listing issues

### DIFF
--- a/app/Http/Controllers/CandidateController.php
+++ b/app/Http/Controllers/CandidateController.php
@@ -86,7 +86,15 @@ class CandidateController extends Controller
             return Oep::where('is_active', true)->select('id', 'name', 'code')->get();
         });
 
-        return view('candidates.create', compact('campuses', 'trades', 'oeps'));
+        // FIX: Include batches with trade relationship for the create form
+        $batches = Cache::remember('active_batches_with_trades', 3600, function () {
+            return Batch::with('trade:id,name')
+                ->where('status', 'active')
+                ->select('id', 'batch_code', 'name', 'trade_id')
+                ->get();
+        });
+
+        return view('candidates.create', compact('campuses', 'trades', 'oeps', 'batches'));
     }
 
     public function store(Request $request)
@@ -101,8 +109,8 @@ class CandidateController extends Controller
             'date_of_birth' => 'required|date|before:today',
             'gender' => 'required|in:male,female,other',
             'phone' => 'required|string|max:20',
-            'email' => 'required|email|max:255',
-            'address' => 'required|string',
+            'email' => 'nullable|email|max:255',
+            'address' => 'nullable|string',
             'district' => 'required|string|max:100',
             'tehsil' => 'nullable|string|max:100',
             'trade_id' => 'required|exists:trades,id',

--- a/app/Models/Candidate.php
+++ b/app/Models/Candidate.php
@@ -169,6 +169,14 @@ class Candidate extends Model
     }
 
     /**
+     * Get the OEP (Overseas Employment Promoter) assigned to the candidate.
+     */
+    public function oep()
+    {
+        return $this->belongsTo(Oep::class);
+    }
+
+    /**
      * Get the next of kin for the candidate.
      */
     public function nextOfKin()

--- a/resources/views/candidates/create.blade.php
+++ b/resources/views/candidates/create.blade.php
@@ -17,6 +17,23 @@
         </div>
     </div>
 
+    <!-- Error Summary -->
+    @if ($errors->any())
+    <div class="bg-red-100 border border-red-400 text-red-700 px-4 py-3 rounded-lg mb-6">
+        <div class="flex items-start">
+            <i class="fas fa-exclamation-circle mt-1 mr-3"></i>
+            <div>
+                <p class="font-semibold">Please fix the following errors:</p>
+                <ul class="list-disc list-inside mt-2 text-sm">
+                    @foreach ($errors->all() as $error)
+                        <li>{{ $error }}</li>
+                    @endforeach
+                </ul>
+            </div>
+        </div>
+    </div>
+    @endif
+
     <!-- Form Card -->
     <div class="bg-white rounded-lg shadow-md p-8">
         <form action="{{ route('candidates.store') }}" method="POST" enctype="multipart/form-data" class="space-y-8">
@@ -133,13 +150,14 @@
                 <div class="grid grid-cols-1 md:grid-cols-2 gap-6">
                     <!-- Campus -->
                     <div>
-                        <label class="block text-sm font-medium text-gray-700 mb-2">Campus *</label>
-                        <select name="campus_id" class="w-full px-4 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-blue-500 focus:border-transparent @error('campus_id') border-red-500 @enderror" required>
-                            <option value="">Select Campus</option>
+                        <label class="block text-sm font-medium text-gray-700 mb-2">Campus (Optional)</label>
+                        <select name="campus_id" class="w-full px-4 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-blue-500 focus:border-transparent @error('campus_id') border-red-500 @enderror">
+                            <option value="">Select Campus (can be assigned later)</option>
                             @foreach($campuses ?? [] as $campus)
                                 <option value="{{ $campus->id }}" {{ old('campus_id') == $campus->id ? 'selected' : '' }}>{{ $campus->name }}</option>
                             @endforeach
                         </select>
+                        <p class="text-xs text-gray-500 mt-1">Campus can be assigned later from candidate profile</p>
                         @error('campus_id')<span class="text-red-500 text-sm">{{ $message }}</span>@enderror
                     </div>
 


### PR DESCRIPTION
Issues fixed:
- Add missing oep() relationship to Candidate model (was causing errors when eager loading OEP data)
- Add batches to candidate create view (was missing from controller)
- Make email and address optional in validation (matching form labels)
- Make campus optional with helpful text (can be assigned later)
- Add error summary section to candidate create form
- Fix validation inconsistencies between form and controller

These fixes ensure the candidate single entry and bulk import functionality work correctly without errors.