### PR TITLE
fix: Make migrations idempotent for existing databases

### DIFF
--- a/database/migrations/2025_12_19_000001_create_next_of_kins_table.php
+++ b/database/migrations/2025_12_19_000001_create_next_of_kins_table.php
@@ -14,6 +14,11 @@ return new class extends Migration
      */
     public function up(): void
     {
+        // Skip if table already exists (idempotent migration)
+        if (Schema::hasTable('next_of_kins')) {
+            return;
+        }
+
         Schema::create('next_of_kins', function (Blueprint $table) {
             $table->id();
 

--- a/database/migrations/2025_12_19_000005_create_training_schedules_table.php
+++ b/database/migrations/2025_12_19_000005_create_training_schedules_table.php
@@ -14,6 +14,11 @@ return new class extends Migration
      */
     public function up(): void
     {
+        // Skip if table already exists (idempotent migration)
+        if (Schema::hasTable('training_schedules')) {
+            return;
+        }
+
         Schema::create('training_schedules', function (Blueprint $table) {
             $table->id();
 


### PR DESCRIPTION
Updated migrations to safely skip if tables/columns already exist:
- next_of_kins: Added Schema::hasTable() check before create
- training_schedules: Added Schema::hasTable() check before create
- add_security_columns_to_users: Fixed foreign key constraint logic to use try-catch instead of incorrect column checks

These changes allow migrations to run on databases that already have some of these tables/columns from previous deployments.