### PR TITLE
fix: Prevent duplicate column error in training_assessments migration

### DIFF
--- a/database/migrations/2026_01_05_000001_add_result_column_to_training_assessments.php
+++ b/database/migrations/2026_01_05_000001_add_result_column_to_training_assessments.php
@@ -23,25 +23,50 @@ return new class extends Migration
     {
         Schema::table('training_assessments', function (Blueprint $table) {
             // Add result column after grade column
-            $table->string('result', 20)->nullable()->after('grade');
+            if (!Schema::hasColumn('training_assessments', 'result')) {
+                $table->string('result', 20)->nullable()->after('grade');
+            }
 
             // Add pass_score column for determining pass/fail threshold
-            $table->decimal('pass_score', 5, 2)->default(60)->after('total_marks');
+            if (!Schema::hasColumn('training_assessments', 'pass_score')) {
+                $table->decimal('pass_score', 5, 2)->default(60)->after('total_marks');
+            }
 
             // Add max_score as alias for total_marks (for consistency with code)
-            $table->decimal('max_score', 5, 2)->nullable()->after('pass_score');
+            if (!Schema::hasColumn('training_assessments', 'max_score')) {
+                $table->decimal('max_score', 5, 2)->nullable()->after('pass_score');
+            }
 
             // Additional columns used in TrainingService::recordAssessment
-            $table->decimal('theoretical_score', 5, 2)->nullable()->after('score');
-            $table->decimal('practical_score', 5, 2)->nullable()->after('theoretical_score');
-            $table->decimal('total_score', 5, 2)->nullable()->after('practical_score');
-            $table->unsignedBigInteger('trainer_id')->nullable()->after('remarks');
-            $table->string('assessment_location')->nullable()->after('trainer_id');
-            $table->boolean('remedial_needed')->default(false)->after('assessment_location');
+            if (!Schema::hasColumn('training_assessments', 'theoretical_score')) {
+                $table->decimal('theoretical_score', 5, 2)->nullable()->after('score');
+            }
+            if (!Schema::hasColumn('training_assessments', 'practical_score')) {
+                $table->decimal('practical_score', 5, 2)->nullable()->after('theoretical_score');
+            }
+            if (!Schema::hasColumn('training_assessments', 'total_score')) {
+                $table->decimal('total_score', 5, 2)->nullable()->after('practical_score');
+            }
 
-            // Add index for performance
-            $table->index(['candidate_id', 'assessment_type', 'result']);
+            // Note: trainer_id and assessment_location already added in 2025_11_04_add_missing_columns.php
+            if (!Schema::hasColumn('training_assessments', 'trainer_id')) {
+                $table->unsignedBigInteger('trainer_id')->nullable()->after('remarks');
+            }
+            if (!Schema::hasColumn('training_assessments', 'assessment_location')) {
+                $table->string('assessment_location')->nullable()->after('trainer_id');
+            }
+
+            if (!Schema::hasColumn('training_assessments', 'remedial_needed')) {
+                $table->boolean('remedial_needed')->default(false)->after('assessment_location');
+            }
         });
+
+        // Add index for performance (only if not exists)
+        if (!DB::select("SHOW INDEX FROM training_assessments WHERE Key_name = 'training_assessments_candidate_id_assessment_type_result_index'")) {
+            Schema::table('training_assessments', function (Blueprint $table) {
+                $table->index(['candidate_id', 'assessment_type', 'result']);
+            });
+        }
 
         // Update existing records: derive result from score/total_marks
         // If score >= 60% of total_marks, result = 'pass', else 'fail'
@@ -60,18 +85,33 @@ return new class extends Migration
     public function down(): void
     {
         Schema::table('training_assessments', function (Blueprint $table) {
-            $table->dropIndex(['candidate_id', 'assessment_type', 'result']);
-            $table->dropColumn([
+            // Drop index if it exists
+            if (DB::select("SHOW INDEX FROM training_assessments WHERE Key_name = 'training_assessments_candidate_id_assessment_type_result_index'")) {
+                $table->dropIndex(['candidate_id', 'assessment_type', 'result']);
+            }
+
+            // Drop columns if they exist
+            $columnsToCheck = [
                 'result',
                 'pass_score',
                 'max_score',
                 'theoretical_score',
                 'practical_score',
                 'total_score',
-                'trainer_id',
-                'assessment_location',
                 'remedial_needed',
-            ]);
+                // Note: We don't drop trainer_id and assessment_location as they were added in earlier migration
+            ];
+
+            $columnsToDrop = [];
+            foreach ($columnsToCheck as $column) {
+                if (Schema::hasColumn('training_assessments', $column)) {
+                    $columnsToDrop[] = $column;
+                }
+            }
+
+            if (!empty($columnsToDrop)) {
+                $table->dropColumn($columnsToDrop);
+            }
         });
     }
 };


### PR DESCRIPTION
ISSUE:
Migration 2026_01_05_000001 was failing with:
"SQLSTATE[42S21]: Column already exists: 1060 Duplicate column name 'trainer_id'"

ROOT CAUSE:
The migration tried to add trainer_id and assessment_location columns, but these were already added in migration 2025_11_04_add_missing_columns.php

FIX APPLIED:
- Added Schema::hasColumn() checks before adding all columns
- Added DB check before creating index to prevent duplicate index error
- Updated down() method to safely drop columns only if they exist
- Added comments noting which columns were added in earlier migrations

COLUMNS PROTECTED:
- trainer_id (already exists from 2025_11_04)
- assessment_location (already exists from 2025_11_04)
- result, pass_score, max_score (new columns with guards)
- theoretical_score, practical_score, total_score (new columns with guards)
- remedial_needed (new column with guard)

This makes the migration idempotent and safe to run multiple times.

TESTING:
- Migration will now succeed on fresh databases
- Migration will now succeed on databases with existing columns
- Rollback is safe and checks column existence before dropping