### PR TITLE
fix: Correct correspondence seeder column names to match schema

### DIFF
--- a/database/seeders/TestDataSeeder.php
+++ b/database/seeders/TestDataSeeder.php
@@ -717,14 +717,17 @@ class TestDataSeeder extends Seeder
     private function seedCorrespondence($campuses, $oeps)
     {
         for ($i = 0; $i < 10; $i++) {
+            $hasReply = rand(0, 1);
             Correspondence::create([
                 'campus_id' => $i % 2 == 0 ? $campuses[array_rand($campuses)]->id : null,
                 'oep_id' => $i % 2 != 0 ? $oeps[array_rand($oeps)]->id : null,
                 'subject' => 'Subject of correspondence ' . ($i + 1),
-                'content' => 'Brief summary of the correspondence content and main points discussed for correspondence number ' . ($i + 1) . '.',
-                'correspondence_date' => now()->subDays(rand(1, 90)),
-                'reply_date' => rand(0, 1) ? now()->subDays(rand(1, 30)) : null,
-                'reply_content' => rand(0, 1) ? 'Reply to the correspondence with relevant information and updates.' : null,
+                'message' => 'Brief summary of the correspondence content and main points discussed for correspondence number ' . ($i + 1) . '.',
+                'sent_at' => now()->subDays(rand(1, 90)),
+                'replied' => $hasReply,
+                'replied_at' => $hasReply ? now()->subDays(rand(1, 30)) : null,
+                'status' => $hasReply ? 'replied' : 'pending',
+                'requires_reply' => true,
             ]);
         }
     }


### PR DESCRIPTION
ISSUE:
TestDataSeeder was failing with:
'SQLSTATE[42S22]: Column not found: 1054 Unknown column 'content''

ROOT CAUSE:
Seeder was using incorrect column names that don't exist in correspondences table:
- 'content' → should be 'message'
- 'correspondence_date' → should be 'sent_at'
- 'reply_date' → should be 'replied_at'
- 'reply_content' → doesn't exist (no reply message column in schema)

FIX APPLIED:
Updated seedCorrespondence() method to use correct column names from 2025_10_31_165531_create_correspondences_table.php migration:
- Changed 'content' to 'message'
- Changed 'correspondence_date' to 'sent_at'
- Changed 'reply_date' to 'replied_at'
- Removed 'reply_content' (not in schema)
- Added 'replied' boolean flag
- Added 'status' field (pending/replied)
- Added 'requires_reply' flag

This matches the actual database schema defined in the migration.