### PR TITLE
Replace morphs() with explicit polymorphic columns in document renewal requests

### DIFF
--- a/database/migrations/2026_04_09_000002_create_document_renewal_requests_table.php
+++ b/database/migrations/2026_04_09_000002_create_document_renewal_requests_table.php
@@ -12,7 +12,9 @@ return new class extends Migration
             $table->id();
             $table->foreignId('candidate_id')->constrained()->cascadeOnDelete();
             $table->string('document_type', 50);
-            $table->morphs('documentable');
+            $table->string('documentable_type');
+            $table->unsignedBigInteger('documentable_id');
+            $table->index(['documentable_type', 'documentable_id'], 'drr_documentable_index');
             $table->date('current_expiry_date')->nullable();
             $table->date('requested_date');
             $table->enum('status', ['pending', 'in_progress', 'completed', 'cancelled'])->default('pending');


### PR DESCRIPTION
## Summary
Refactored the `document_renewal_requests` table migration to use explicit polymorphic relationship columns instead of Laravel's `morphs()` helper method.

## Key Changes
- Replaced `$table->morphs('documentable')` with explicit column definitions:
  - `documentable_type` (string column)
  - `documentable_id` (unsigned big integer column)
- Added a composite index on `documentable_type` and `documentable_id` for improved query performance

## Implementation Details
This change maintains the same polymorphic relationship functionality while providing more explicit control over the column definitions. The composite index on the polymorphic columns ensures efficient queries when filtering by documentable type and ID combinations.

https://claude.ai/code/session_01P9RQnH7xxxqZ8rrZELcR67