### PR TITLE
Refactor Country query method from destinationCountries to destinations

### DIFF
--- a/app/Http/Controllers/EmployerController.php
+++ b/app/Http/Controllers/EmployerController.php
@@ -56,7 +56,7 @@ class EmployerController extends Controller
         }
 
         $employers = $query->latest()->paginate(20);
-        $countries = Country::destinationCountries()->active()->get();
+        $countries = Country::destinations()->active()->get();
 
         return view('admin.employers.index', compact('employers', 'countries'));
     }
@@ -68,7 +68,7 @@ class EmployerController extends Controller
     {
         $this->authorize('create', Employer::class);
 
-        $countries = Country::destinationCountries()->active()->get();
+        $countries = Country::destinations()->active()->get();
         $trades = Trade::active()->orderBy('name')->get();
 
         return view('admin.employers.create', compact('countries', 'trades'));
@@ -144,7 +144,7 @@ class EmployerController extends Controller
     {
         $this->authorize('update', $employer);
 
-        $countries = Country::destinationCountries()->active()->get();
+        $countries = Country::destinations()->active()->get();
         $trades = Trade::active()->orderBy('name')->get();
 
         return view('admin.employers.edit', compact('employer', 'countries', 'trades'));


### PR DESCRIPTION
## Summary
This PR refactors the Country model query method calls across the EmployerController from `destinationCountries()` to `destinations()` for improved naming consistency and clarity.

## Key Changes
- Updated 3 occurrences in EmployerController where countries are fetched:
  - `index()` method
  - `create()` method
  - `edit()` method
- Changed `Country::destinationCountries()->active()->get()` to `Country::destinations()->active()->get()`

## Implementation Details
This appears to be a method rename on the Country model to use a shorter, more concise query method name. The functionality remains identical - fetching active destination countries for use in employer management views. The change improves code readability and maintains consistency with naming conventions across the codebase.

https://claude.ai/code/session_01PvRhZMDNQBxe52iG3gzBGY