### PR TITLE
Update blade templates to extend app layout instead of admin

### DIFF
--- a/resources/views/admin/employers/candidates.blade.php
+++ b/resources/views/admin/employers/candidates.blade.php
@@ -1,4 +1,4 @@
-@extends('layouts.admin')
+@extends('layouts.app')
 
 @section('title', 'Employer Candidates - ' . $employer->visa_issuing_company)
 

--- a/resources/views/admin/employers/create.blade.php
+++ b/resources/views/admin/employers/create.blade.php
@@ -1,4 +1,4 @@
-@extends('layouts.admin')
+@extends('layouts.app')
 
 @section('title', 'Add New Employer')
 

--- a/resources/views/admin/employers/dashboard.blade.php
+++ b/resources/views/admin/employers/dashboard.blade.php
@@ -1,4 +1,4 @@
-@extends('layouts.admin')
+@extends('layouts.app')
 
 @section('title', 'Employer Dashboard')
 

--- a/resources/views/admin/employers/edit.blade.php
+++ b/resources/views/admin/employers/edit.blade.php
@@ -1,4 +1,4 @@
-@extends('layouts.admin')
+@extends('layouts.app')
 
 @section('title', 'Edit Employer')
 

--- a/resources/views/admin/employers/index.blade.php
+++ b/resources/views/admin/employers/index.blade.php
@@ -1,4 +1,4 @@
-@extends('layouts.admin')
+@extends('layouts.app')
 
 @section('title', 'Employers')
 

--- a/resources/views/admin/employers/show.blade.php
+++ b/resources/views/admin/employers/show.blade.php
@@ -1,4 +1,4 @@
-@extends('layouts.admin')
+@extends('layouts.app')
 
 @section('title', 'Employer Details - ' . $employer->visa_issuing_company)
 

--- a/resources/views/admin/pre-departure-documents/index.blade.php
+++ b/resources/views/admin/pre-departure-documents/index.blade.php
@@ -1,4 +1,4 @@
-@extends('layouts.admin')
+@extends('layouts.app')
 
 @section('title', 'Pre-Departure Documents - ' . $candidate->name)
 

--- a/resources/views/admin/training-assessments/create.blade.php
+++ b/resources/views/admin/training-assessments/create.blade.php
@@ -1,4 +1,4 @@
-@extends('layouts.admin')
+@extends('layouts.app')
 
 @section('title', 'Create Training Assessment')
 

--- a/resources/views/complaints/form.blade.php
+++ b/resources/views/complaints/form.blade.php
@@ -1,4 +1,4 @@
-@extends('layouts.admin')
+@extends('layouts.app')
 
 @section('title', isset($complaint) ? 'Edit Complaint' : 'Register Complaint')
 

--- a/resources/views/departures/form.blade.php
+++ b/resources/views/departures/form.blade.php
@@ -1,4 +1,4 @@
-@extends('layouts.admin')
+@extends('layouts.app')
 
 @section('title', isset($departure) ? 'Edit Departure' : 'Create Departure')
 

--- a/resources/views/registration/form.blade.php
+++ b/resources/views/registration/form.blade.php
@@ -1,4 +1,4 @@
-@extends('layouts.admin')
+@extends('layouts.app')
 
 @section('title', 'Candidate Registration - ' . $candidate->name)
 

--- a/resources/views/screenings/form.blade.php
+++ b/resources/views/screenings/form.blade.php
@@ -1,4 +1,4 @@
-@extends('layouts.admin')
+@extends('layouts.app')
 
 @section('title', 'Initial Screening - ' . $candidate->name)
 

--- a/resources/views/success-stories/form.blade.php
+++ b/resources/views/success-stories/form.blade.php
@@ -1,4 +1,4 @@
-@extends('layouts.admin')
+@extends('layouts.app')
 
 @section('title', isset($successStory) ? 'Edit Success Story' : 'Record Success Story')
 


### PR DESCRIPTION
## Summary
This PR updates 13 blade template files to extend the `layouts.app` layout instead of `layouts.admin`. This change standardizes the layout inheritance across the application and likely reflects a refactoring of the layout structure.

## Key Changes
- Updated all employer management views (candidates, create, dashboard, edit, index, show)
- Updated pre-departure documents view
- Updated training assessments create view
- Updated complaint form view
- Updated departure form view
- Updated candidate registration form view
- Updated screening form view
- Updated success stories form view

All changes involve replacing `@extends('layouts.admin')` with `@extends('layouts.app')` at the top of each template file.

## Implementation Details
This appears to be a layout consolidation effort, moving away from a separate admin layout to a unified app layout. This change affects 13 views across multiple feature areas including employer management, candidate registration, complaints, departures, screenings, and success stories.

https://claude.ai/code/session_01M4E6Aaps3cyNxpRmqnXvot