### PR TITLE
Fix route names and parameters in CandidateJourneyService

### DIFF
--- a/app/Services/CandidateJourneyService.php
+++ b/app/Services/CandidateJourneyService.php
@@ -287,11 +287,11 @@ class CandidateJourneyService
                 break;
 
             case 'training_completed':
-                $actions[] = ['action' => 'Start Visa Processing', 'url' => route('visa.create', $candidate)];
+                $actions[] = ['action' => 'Start Visa Processing', 'url' => route('visa-processing.create', $candidate)];
                 break;
 
             case 'visa_process':
-                $actions[] = ['action' => 'Update Visa Stage', 'url' => route('visa.show', $candidate->visaProcess ?? $candidate)];
+                $actions[] = ['action' => 'Update Visa Stage', 'url' => route('visa-processing.show', $candidate)];
                 break;
 
             case 'visa_approved':
@@ -304,11 +304,11 @@ class CandidateJourneyService
                 break;
 
             case 'departed':
-                $actions[] = ['action' => 'Complete Post-Departure Setup', 'url' => route('post-departure.show', $candidate)];
+                $actions[] = ['action' => 'Complete Post-Departure Setup', 'url' => route('post-departure.show', ['candidate' => $candidate])];
                 break;
 
             case 'post_departure':
-                $actions[] = ['action' => 'Verify 90-Day Compliance', 'url' => route('post-departure.show', $candidate)];
+                $actions[] = ['action' => 'Verify 90-Day Compliance', 'url' => route('post-departure.show', ['candidate' => $candidate])];
                 break;
         }
 


### PR DESCRIPTION
## Summary

Corrects route names and parameter passing in the `CandidateJourneyService.getNextRequiredActions()` method to align with actual route definitions and ensure proper URL generation for visa processing and post-departure actions.

## Changes

- **Visa Processing routes:** Updated route names from `visa.create` and `visa.show` to `visa-processing.create` and `visa-processing.show` to match the actual route definitions
- **Visa Processing parameters:** Simplified the `visa.show` route call to pass `$candidate` directly instead of the conditional `$candidate->visaProcess ?? $candidate` logic
- **Post-Departure routes:** Updated parameter passing for `post-departure.show` routes to use explicit array syntax `['candidate' => $candidate]` for consistency and clarity

## Implementation Details

These changes ensure that:
1. Route generation doesn't fail due to undefined route names
2. The correct candidate context is passed to visa processing and post-departure views
3. Route parameter passing follows a consistent pattern across the service
4. The journey action URLs properly resolve to their corresponding controller actions

https://claude.ai/code/session_01PnoecHGwga1zR25jsLkm3m