### PR TITLE
Add visa processing stage update routes for candidate workflow

### DIFF
--- a/routes/web.php
+++ b/routes/web.php
@@ -369,6 +369,18 @@ Route::middleware(['auth'])->group(function () {
         Route::resource('visa-processing', VisaProcessingController::class)
             ->parameters(['visa-processing' => 'candidate']);
         Route::prefix('visa-processing')->name('visa-processing.')->group(function () {
+            // Interview, Trade Test, Takamol, Medical, Biometric, Visa, PTN
+            Route::post('/{candidate}/update-interview', [VisaProcessingController::class, 'updateInterview'])->name('update-interview');
+            Route::post('/{candidate}/update-trade-test', [VisaProcessingController::class, 'updateTradeTest'])->name('update-trade-test');
+            Route::post('/{candidate}/update-takamol', [VisaProcessingController::class, 'updateTakamol'])->name('update-takamol');
+            Route::post('/{candidate}/upload-takamol-result', [VisaProcessingController::class, 'uploadTakamolResult'])->middleware('throttle:30,1')->name('upload-takamol-result');
+            Route::post('/{candidate}/update-medical', [VisaProcessingController::class, 'updateMedical'])->name('update-medical');
+            Route::post('/{candidate}/upload-gamca-result', [VisaProcessingController::class, 'uploadGamcaResult'])->middleware('throttle:30,1')->name('upload-gamca-result');
+            Route::post('/{candidate}/update-biometric', [VisaProcessingController::class, 'updateBiometric'])->name('update-biometric');
+            Route::post('/{candidate}/update-visa-submission', [VisaProcessingController::class, 'updateVisaSubmission'])->name('update-visa-submission');
+            Route::post('/{candidate}/update-visa', [VisaProcessingController::class, 'updateVisa'])->name('update-visa');
+            Route::post('/{candidate}/update-ptn', [VisaProcessingController::class, 'updatePTN'])->name('update-ptn');
+
             // E-Number (externally generated, no Module 5 equivalent)
             Route::post('/{candidate}/update-enumber', [VisaProcessingController::class, 'updateEnumber'])->name('update-enumber');
 


### PR DESCRIPTION
## Summary

Adds 10 new POST routes to the visa processing workflow that enable updating various stages of the candidate visa processing pipeline, including interview, trade test, Takamol assessment, medical examination, biometric collection, visa submission, and PTN registration.

## Key Changes

- **Interview stage:** `POST /visa-processing/{candidate}/update-interview`
- **Trade test stage:** `POST /visa-processing/{candidate}/update-trade-test`
- **Takamol assessment:** `POST /visa-processing/{candidate}/update-takamol` with file upload endpoint (`upload-takamol-result`) throttled to 30 requests/minute
- **Medical examination:** `POST /visa-processing/{candidate}/update-medical` with GAMCA result upload (`upload-gamca-result`) throttled to 30 requests/minute
- **Biometric collection:** `POST /visa-processing/{candidate}/update-biometric`
- **Visa submission & approval:** `POST /visa-processing/{candidate}/update-visa-submission` and `update-visa`
- **PTN registration:** `POST /visa-processing/{candidate}/update-ptn`

## Implementation Details

- All routes are nested under the `visa-processing` prefix and use the `VisaProcessingController`
- File upload endpoints include throttle middleware (30 requests per minute) to prevent abuse
- Routes follow the existing parameter binding convention (`{candidate}` maps to candidate model)
- Routes are organized with inline comments grouping related visa processing stages
- Maintains consistency with the existing E-Number route pattern already in the file

https://claude.ai/code/session_017ddVijRTWW3dFhwKq1wZmQ