### PR TITLE
Add visa submission fields to visa process tracking

### DIFF
--- a/app/Models/VisaProcess.php
+++ b/app/Models/VisaProcess.php
@@ -38,6 +38,8 @@ class VisaProcess extends Model
         // Biometrics/Etimad
         'biometric_date', 'etimad_appointment_id', 'biometric_status', 'biometric_completed',
         'biometric_details',
+        // Visa Documents Submission
+        'visa_submission_date', 'visa_application_number', 'embassy',
         // Visa & PTN
         'visa_date', 'visa_number', 'visa_status', 'visa_issued',
         'visa_application_status', 'visa_issued_status', 'visa_application_details',
@@ -61,6 +63,7 @@ class VisaProcess extends Model
         'takamol_date' => 'date',
         'medical_date' => 'date',
         'biometric_date' => 'date',
+        'visa_submission_date' => 'date',
         'visa_date' => 'date',
         'ticket_date' => 'date',
         'ptn_issue_date' => 'date',

--- a/database/migrations/2026_06_08_000002_add_visa_submission_fields_to_visa_processes.php
+++ b/database/migrations/2026_06_08_000002_add_visa_submission_fields_to_visa_processes.php
@@ -1,0 +1,46 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Visa Documents Submission stage fields:
+     * - visa_submission_date: date the documents were submitted to the embassy
+     * - visa_application_number: tracking/reference number for the submission
+     * - embassy: embassy where documents were submitted
+     */
+    public function up(): void
+    {
+        Schema::table('visa_processes', function (Blueprint $table) {
+            if (! Schema::hasColumn('visa_processes', 'visa_submission_date')) {
+                $table->date('visa_submission_date')->nullable()->after('biometric_details');
+            }
+            if (! Schema::hasColumn('visa_processes', 'visa_application_number')) {
+                $table->string('visa_application_number', 100)->nullable()->after('visa_submission_date');
+            }
+            if (! Schema::hasColumn('visa_processes', 'embassy')) {
+                $table->string('embassy')->nullable()->after('visa_application_number');
+            }
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('visa_processes', function (Blueprint $table) {
+            $columns = [
+                'visa_submission_date',
+                'visa_application_number',
+                'embassy',
+            ];
+
+            foreach ($columns as $column) {
+                if (Schema::hasColumn('visa_processes', $column)) {
+                    $table->dropColumn($column);
+                }
+            }
+        });
+    }
+};


### PR DESCRIPTION
## Summary

Adds three new fields to the `visa_processes` table to track the visa documents submission stage, enabling better visibility into the visa application pipeline.

## Changes

- **Migration:** Added three nullable columns to `visa_processes` table:
  - `visa_submission_date` (date) - Records when documents were submitted to the embassy
  - `visa_application_number` (string, max 100) - Stores the tracking/reference number for the submission
  - `embassy` (string) - Records which embassy received the documents

- **Model:** Updated `VisaProcess` model to:
  - Add new fields to the `$fillable` array under a "Visa Documents Submission" section
  - Cast `visa_submission_date` to date type for proper handling

## Implementation Details

- Fields are positioned after `biometric_details` in the table schema, maintaining logical workflow progression through the visa process stages
- All fields are nullable to support gradual data entry as candidates progress through the submission stage
- Migration includes defensive checks (`Schema::hasColumn()`) to prevent errors if columns already exist
- Rollback properly handles column removal with existence checks

https://claude.ai/code/session_01S3NMGngnGr3oaGYviEEKRq