### PR TITLE
Refactor role dropdown to use key-value pairs in user forms

### DIFF
--- a/resources/views/admin/users/create.blade.php
+++ b/resources/views/admin/users/create.blade.php
@@ -83,9 +83,9 @@
                 <select name="role" id="role" required
                         class="w-full px-4 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-blue-500 focus:border-transparent @error('role') border-red-500 @enderror">
                     <option value="">Select Role</option>
-                    @foreach($roles ?? [] as $role)
-                        <option value="{{ $role }}" {{ old('role') === $role ? 'selected' : '' }}>
-                            {{ ucfirst(str_replace('_', ' ', $role)) }}
+                    @foreach($roles ?? [] as $value => $label)
+                        <option value="{{ $value }}" {{ old('role') === $value ? 'selected' : '' }}>
+                            {{ $label }}
                         </option>
                     @endforeach
                 </select>

--- a/resources/views/admin/users/edit.blade.php
+++ b/resources/views/admin/users/edit.blade.php
@@ -82,9 +82,9 @@
                 </label>
                 <select name="role" id="role" required
                         class="w-full px-4 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-blue-500 focus:border-transparent @error('role') border-red-500 @enderror">
-                    @foreach($roles ?? [] as $role)
-                        <option value="{{ $role }}" {{ old('role', $user->role) === $role ? 'selected' : '' }}>
-                            {{ ucfirst(str_replace('_', ' ', $role)) }}
+                    @foreach($roles ?? [] as $value => $label)
+                        <option value="{{ $value }}" {{ old('role', $user->role) === $value ? 'selected' : '' }}>
+                            {{ $label }}
                         </option>
                     @endforeach
                 </select>


### PR DESCRIPTION
## Summary

Refactored the role selection dropdowns in user create and edit forms to accept pre-formatted key-value pairs from the controller, eliminating the need for string manipulation in the view layer.

## Changes

- **create.blade.php & edit.blade.php:** Updated role dropdown iteration to destructure `$roles` array as `$value => $label` pairs
- Removed `ucfirst(str_replace('_', ' ', $role))` string transformation from views
- Updated option value binding to use `$value` instead of `$role`
- Updated selected state comparison to use `$value` instead of `$role`

## Implementation Details

This change shifts responsibility for role label formatting from the Blade template to the controller layer, following the principle of separation of concerns. The controller now provides pre-formatted display labels (e.g., "Super Admin", "Campus Admin") while the view simply renders them without transformation logic.

**Expected controller change:**
```php
// Before: $roles = ['super_admin', 'admin', 'campus_admin']
// After: $roles = ['super_admin' => 'Super Admin', 'admin' => 'Admin', ...]
```

This improves maintainability and makes role label definitions centralized and testable.

https://claude.ai/code/session_01Xncy71iQoLFjjd7Dykb2yG